### PR TITLE
feat: add recommend-new-approaches skill (stage 10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,20 @@ When modifying or adding skills, keep these files in sync:
 
 - `plugins/agentic-ml/references/schemas.md` — JSON output schemas for all skills
 - `plugins/agentic-ml/references/vocabulary.md` — canonical enum values
-- plugin version using semver
+- plugin version using semver (`plugins/agentic-ml/.claude-plugin/plugin.json`)
 - `README.md` — Available Skills table and Repository Structure tree
+- `CHANGELOG.md` — add an entry under `[Unreleased]` describing what changed
+
+### Changelog conventions
+
+`CHANGELOG.md` is updated manually alongside code changes. The GitHub release workflow (`.github/workflows/release.yml`) generates release notes independently from `git log` and does **not** read `CHANGELOG.md` — the two are maintained in parallel.
+
+When bumping the plugin version for a release, move the `[Unreleased]` entries under a new versioned heading (e.g. `## [0.3.0] — YYYY-MM-DD`) before merging. Use the same category headings the release workflow uses:
+
+- `### 🛠 Skills & Features` — new skills, new arguments, behavior changes
+- `### 🐛 Bug Fixes` — correctness fixes
+- `### 📚 Documentation` — README, AGENTS.md, reference docs
+- `### 🔧 Maintenance` — CI, dependencies, refactors with no user-visible change
 
 ## Structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format follows the categories used in the automated release workflow (`.github/workflows/release.yml`): **Skills & Features**, **Bug Fixes**, **Documentation**, **Maintenance**. Releases correspond to tags in the repository and version entries in `plugins/agentic-ml/.claude-plugin/plugin.json`.
+
+---
+
+## [Unreleased]
+
+### 🛠 Skills & Features
+
+- feat: add `recommend-new-approaches` skill — generates prioritized research directions, modeling ideas, and loss function modifications from training artifacts; optionally leverages [autoresearch](https://github.com/karpathy/autoresearch)
+- feat: integrate `recommend-new-approaches` as step 5d in `orchestrate-e2e` (always runs after eval/interpretability gates, before promotion decision)
+
+### 📚 Documentation
+
+- docs: add stage-order column to Available Skills table in README
+- docs: clarify `babysit-training` can be invoked standalone when training is already running
+
+---
+
+## [0.2.0] — 2026-02-27
+
+### 🛠 Skills & Features
+
+- feat: add `train-model` skill — launches and manages training with early stopping, HP config, and checkpoint management; delegates monitoring to `babysit-training`
+- feat: add `demonstrate-value` skill — synthesizes evaluation and explainability results into a stakeholder-ready HTML presentation using showboat
+- feat: add exponential backoff in `babysit-training` monitoring loop to reduce polling overhead on long runs
+
+### 🔧 Maintenance
+
+- chore: bump `actions/checkout` to v6
+
+---
+
+## [0.1.0] — 2026-01-01
+
+Initial release.
+
+### 🛠 Skills & Features
+
+- feat: `review-target` — validate label/target definition, leakage risk, metric alignment, and split strategy
+- feat: `plan-experiment` — design a structured experiment plan with hypothesis, model candidates, HP search space, and compute budget
+- feat: `build-baseline` — build and evaluate non-ML baselines to establish the performance floor
+- feat: `check-dataset-quality` — profile and validate datasets (CSV, Parquet, JSONL, HuggingFace, image dirs, DB tables)
+- feat: `check-data-pipeline` — dry-run a preprocessing pipeline on a small sample to catch shape/dtype/label issues
+- feat: `feature-engineer` — explore data sources and design leakage-safe feature sets
+- feat: `babysit-training` — continuously monitor a training run (local, SSH, Vertex AI) until terminal state
+- feat: `check-failed-run` — diagnose failed/unstable runs, classify root causes, produce recovery plan
+- feat: `check-eval` — evaluate a checkpoint via HF Trainer, lm-evaluation-harness, or custom script
+- feat: `explain-model` — generate feature importance, bias audit, and model card
+- feat: `orchestrate-e2e` — coordinate the full ML lifecycle with explicit stage gates and Go/No-Go decision
+- feat: `benchmark-e2e` — compare no-plugin/plugin/automl workflow approaches across ML scenarios
+- feat: JSON artifact schema and canonical vocabulary shared across all skills
+- feat: HTML report viewer (`report-viewer/generate_report.py`) for gate timelines and per-skill findings
+- feat: automated GitHub release workflow with conventional-commit categorisation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format follows the categories used in the automated release workflow (`.gith
 
 ## [Unreleased]
 
+---
+
+## [0.3.0] — 2026-03-18
+
 ### 🛠 Skills & Features
 
 - feat: add `recommend-new-approaches` skill — generates prioritized research directions, modeling ideas, and loss function modifications from training artifacts; optionally leverages [autoresearch](https://github.com/karpathy/autoresearch)
@@ -17,6 +21,7 @@ The format follows the categories used in the automated release workflow (`.gith
 
 - docs: add stage-order column to Available Skills table in README
 - docs: clarify `babysit-training` can be invoked standalone when training is already running
+- docs: add `CHANGELOG.md` and document update convention in `AGENTS.md`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -53,22 +53,23 @@ Run complete ML lifecycle but use [mlscribe](https://github.com/lawwu/mlscribe) 
 
 ## Available Skills
 
-| Skill | Lifecycle stage | Description |
-|-------|----------------|-------------|
-| [review-target](plugins/agentic-ml/skills/review-target/SKILL.md) | Problem framing | Validate label/target definition, leakage risk, metric alignment, and split strategy before modeling |
-| [plan-experiment](plugins/agentic-ml/skills/plan-experiment/SKILL.md) | Pre-training | Design a structured experiment plan with hypothesis, model candidates, HP search space, compute budget, and ordered execution |
-| [build-baseline](plugins/agentic-ml/skills/build-baseline/SKILL.md) | Pre-training | Build and evaluate non-ML baselines (majority class, mean predictor, simple rules) to establish the performance floor ML must beat |
-| [check-dataset-quality](plugins/agentic-ml/skills/check-dataset-quality/SKILL.md) | Pre-training | Profile and validate CSV, Parquet, JSONL, HuggingFace datasets, database tables, or image directories |
-| [check-data-pipeline](plugins/agentic-ml/skills/check-data-pipeline/SKILL.md) | Pre-training | Dry-run a preprocessing pipeline on a small sample to catch shape, dtype, padding, and label encoding issues |
-| [feature-engineer](plugins/agentic-ml/skills/feature-engineer/SKILL.md) | Pre-training | Explore files or database tables and design leakage-safe feature sets tied to label and business outcome |
-| [babysit-training](plugins/agentic-ml/skills/babysit-training/SKILL.md) | Training | Continuously monitor a training run (local, remote SSH, or Vertex AI) until it completes or hits a critical issue |
-| [train-model](plugins/agentic-ml/skills/train-model/SKILL.md) | Training | Launch and manage training with early stopping, HP config, and checkpoint management |
-| [check-failed-run](plugins/agentic-ml/skills/check-failed-run/SKILL.md) | Training | Diagnose a failed or unstable training run, classify root causes, and produce a prioritized recovery plan |
-| [check-eval](plugins/agentic-ml/skills/check-eval/SKILL.md) | Post-training | Evaluate a checkpoint via HF Trainer, lm-evaluation-harness, or a custom script with baseline comparison |
-| [explain-model](plugins/agentic-ml/skills/explain-model/SKILL.md) | Post-eval | Generate feature importance, bias audit, and model card before promotion |
-| [demonstrate-value](plugins/agentic-ml/skills/demonstrate-value/SKILL.md) | Post-eval | Create a visual business value presentation using showboat |
-| [orchestrate-e2e](plugins/agentic-ml/skills/orchestrate-e2e/SKILL.md) | Orchestration | Coordinate the full ML lifecycle with explicit stage gates and a final Go/No-Go decision |
-| [benchmark-e2e](plugins/agentic-ml/skills/benchmark-e2e/SKILL.md) | Meta | Compare E2E workflow approaches (no-plugin/plugin/automl) across scenarios (hard-fraud, hard-attrition, xhard-churn) to measure agent reliability, pitfall detection, and cost |
+| Stage | Skill | Lifecycle stage | Description |
+|-------|-------|----------------|-------------|
+| 1 | [review-target](plugins/agentic-ml/skills/review-target/SKILL.md) | Problem framing | Validate label/target definition, leakage risk, metric alignment, and split strategy before modeling |
+| 2 | [plan-experiment](plugins/agentic-ml/skills/plan-experiment/SKILL.md) | Pre-training | Design a structured experiment plan with hypothesis, model candidates, HP search space, compute budget, and ordered execution |
+| 3 | [build-baseline](plugins/agentic-ml/skills/build-baseline/SKILL.md) | Pre-training | Build and evaluate non-ML baselines (majority class, mean predictor, simple rules) to establish the performance floor ML must beat |
+| 4 | [check-dataset-quality](plugins/agentic-ml/skills/check-dataset-quality/SKILL.md) | Pre-training | Profile and validate CSV, Parquet, JSONL, HuggingFace datasets, database tables, or image directories |
+| 5 | [check-data-pipeline](plugins/agentic-ml/skills/check-data-pipeline/SKILL.md) | Pre-training | Dry-run a preprocessing pipeline on a small sample to catch shape, dtype, padding, and label encoding issues |
+| — | [feature-engineer](plugins/agentic-ml/skills/feature-engineer/SKILL.md) | Pre-training | Explore files or database tables and design leakage-safe feature sets tied to label and business outcome |
+| 6 | [train-model](plugins/agentic-ml/skills/train-model/SKILL.md) | Training | Launch and manage training with early stopping, HP config, and checkpoint management; delegates monitoring to babysit-training |
+| 6b | [babysit-training](plugins/agentic-ml/skills/babysit-training/SKILL.md) | Training | Continuously monitor a training run (local, remote SSH, or Vertex AI) until it completes or hits a critical issue; can also be invoked standalone when training is already running |
+| 6c | [check-failed-run](plugins/agentic-ml/skills/check-failed-run/SKILL.md) | Training | Diagnose a failed or unstable training run, classify root causes, and produce a prioritized recovery plan |
+| 7 | [check-eval](plugins/agentic-ml/skills/check-eval/SKILL.md) | Post-training | Evaluate a checkpoint via HF Trainer, lm-evaluation-harness, or a custom script with baseline comparison |
+| 8 | [explain-model](plugins/agentic-ml/skills/explain-model/SKILL.md) | Post-eval | Generate feature importance, bias audit, and model card before promotion |
+| 9 | [demonstrate-value](plugins/agentic-ml/skills/demonstrate-value/SKILL.md) | Post-eval | Create a visual business value presentation using showboat |
+| 10 | [recommend-new-approaches](plugins/agentic-ml/skills/recommend-new-approaches/SKILL.md) | Post-eval | Recommend new research approaches, modeling ideas, and loss function modifications sorted by expected impact; optionally leverages autoresearch |
+| — | [orchestrate-e2e](plugins/agentic-ml/skills/orchestrate-e2e/SKILL.md) | Orchestration | Coordinate the full ML lifecycle with explicit stage gates and a final Go/No-Go decision |
+| — | [benchmark-e2e](plugins/agentic-ml/skills/benchmark-e2e/SKILL.md) | Meta | Compare E2E workflow approaches (no-plugin/plugin/automl) across scenarios (hard-fraud, hard-attrition, xhard-churn) to measure agent reliability, pitfall detection, and cost |
 
 ## Structured Output
 

--- a/plugins/agentic-ml/.claude-plugin/plugin.json
+++ b/plugins/agentic-ml/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-ml",
   "description": "Skills for machine learning workflows: monitoring training runs, debugging models, and managing experiments.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Lawrence Wu"
   }

--- a/plugins/agentic-ml/references/schemas.md
+++ b/plugins/agentic-ml/references/schemas.md
@@ -392,6 +392,39 @@ Written to: `<out-dir>/demonstrate-value.json`
 
 ---
 
+### `recommend-new-approaches`
+
+Written to: `<out-dir>/recommend-new-approaches.json`
+
+```json
+{
+  "model": "<path or null>",
+  "task_type": "classification | regression | ranking | forecasting",
+  "primary_metric": "<metric name>",
+  "current_score": 0.891,
+  "baseline_score": 0.712,
+  "performance_gap": "<text describing gap to target or ideal>",
+  "diagnostic_summary": "<2-3 sentence summary of key weaknesses>",
+  "recommendations": [
+    {
+      "rank": 1,
+      "idea": "<short title>",
+      "rationale": "<grounded in artifact signals>",
+      "category": "architecture | loss | data | training | regularization | other",
+      "expected_impact": "high | medium | low",
+      "effort": "high | medium | low",
+      "next_command": "<concrete CLI command or code change, or null>",
+      "source": "artifact-analysis | literature | autoresearch"
+    }
+  ],
+  "autoresearch_used": false,
+  "autoresearch_path": null,
+  "artifacts_used": ["<path1>", "<path2>"]
+}
+```
+
+---
+
 ### `orchestrate-e2e`
 
 Written to: `<out-dir>/run-summary.json`

--- a/plugins/agentic-ml/skills/orchestrate-e2e/SKILL.md
+++ b/plugins/agentic-ml/skills/orchestrate-e2e/SKILL.md
@@ -106,6 +106,15 @@ If `--business-context` is provided or a business context is clearly inferable f
 - This step does **not** affect the promotion decision — it is informational only
 - If `demonstrate-value` fails, log the error and continue to the promotion step
 
+### 5d. Recommend new approaches (always)
+
+After all evaluation and interpretability gates complete, invoke `recommend-new-approaches`:
+
+- Pass `--out-dir <out-dir> --run-id <run_id>` so it picks up all artifacts automatically
+- This step does **not** affect the promotion decision — it is always informational and forward-looking
+- If `recommend-new-approaches` fails, log the error and continue to the promotion step
+- The recommendations should appear in the final run summary as "Next Experiments"
+
 ### 6. Issue promotion decision
 
 Produce a single decision:

--- a/plugins/agentic-ml/skills/recommend-new-approaches/SKILL.md
+++ b/plugins/agentic-ml/skills/recommend-new-approaches/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: recommend-new-approaches
+description: Recommend new research approaches, modeling ideas, and loss function modifications after a training run completes. Use this skill whenever you want to know what to try next, get modeling improvement suggestions, explore research ideas, suggest architecture changes, propose loss function modifications, or brainstorm next experiments based on the trained model and its metrics. Invoke automatically at the end of orchestrate-e2e or after check-eval to close the loop on every run with actionable next steps. Also use when the user asks "what should I try next?", "how can I improve this model?", "what experiments should I run?", or "what are some ideas to improve performance?".
+argument-hint: "[--out-dir DIR] [--run-id ID] [--model PATH] [--eval-results PATH] [--train-results PATH] [--explain-results PATH] [--task-description TEXT] [--autoresearch]"
+---
+
+# Recommend New Approaches
+
+Synthesize training artifacts into a prioritized list of research directions, modeling ideas, and loss function modifications — sorted by expected impact.
+
+## Invocation
+
+Arguments (`$ARGUMENTS`) are interpreted as:
+
+- `--out-dir DIR` — directory containing run artifacts (default: `./reports/e2e-run`); the skill reads any JSON files found here
+- `--run-id ID` — run ID shared across orchestrated run
+- `--model PATH` — explicit path to trained model or checkpoint (overrides auto-discovery)
+- `--eval-results PATH` — path to `check-eval.json` (default: `<out-dir>/check-eval.json`)
+- `--train-results PATH` — path to `train-model.json` (default: `<out-dir>/train-model.json`)
+- `--explain-results PATH` — path to `explain-model.json` (default: `<out-dir>/explain-model.json`)
+- `--task-description TEXT` — plain-language description of the task and business context (augments artifact data)
+- `--autoresearch` — if set, attempt to use [autoresearch](https://github.com/karpathy/autoresearch) for automated literature-grounded suggestions (requires `autoresearch` installed)
+
+Target: `$ARGUMENTS`
+
+## Your responsibilities
+
+### 1. Load and synthesize run artifacts
+
+Collect all available signals from `--out-dir` or explicit paths:
+
+- `train-model.json` — final metrics, hyperparameters, early stopping info, training duration, best checkpoint
+- `check-eval.json` — task scores, baseline deltas, regressions, best gains
+- `explain-model.json` — top features, PDP shapes, bias audit findings, unexpected patterns
+- `babysit-training.json` — anomalies detected during training (NaN/OOM/divergence/stalled)
+- `check-dataset-quality.json` — dataset profile, class imbalance, data quality findings
+- `review-target.json` — task type, leakage risks, split strategy
+- `plan-experiment.json` — original hypothesis, model family, HP search space
+
+If no artifacts are found, ask for at least one of `--eval-results` or `--train-results` before proceeding. Work with partial data when only some artifacts are present — note which signals were unavailable.
+
+### 2. Diagnose the current model's weaknesses
+
+Before generating ideas, build a brief diagnostic picture:
+
+- **Performance gap**: how far is the model from the promotion threshold or an ideal score?
+- **Training dynamics**: did training converge smoothly, plateau early, or show instability?
+- **Evaluation patterns**: which tasks/slices/classes underperform? Any regressions vs. baseline?
+- **Feature signal**: are top features plausible? Any unexpected patterns or bias findings?
+- **Data constraints**: class imbalance, small dataset, noisy labels, distribution shift signals?
+
+This diagnostic shapes the recommendations — don't skip it even if only one artifact is available.
+
+### 3. Generate recommendations
+
+Produce **5–15 specific, actionable recommendations** across these categories:
+
+| Category | Examples |
+|---|---|
+| `architecture` | model family change, depth/width, attention mechanism, inductive biases |
+| `loss` | focal loss for imbalance, label smoothing, contrastive objectives, auxiliary heads |
+| `data` | augmentation strategy, oversampling/undersampling, semi-supervised data, synthetic data |
+| `training` | learning rate schedule, warmup, gradient clipping, mixed precision, longer training |
+| `regularization` | dropout rate, weight decay, early stopping patience, data augmentation as regularizer |
+| `other` | ensembling, distillation, transfer from related task, feature interaction terms |
+
+For each recommendation:
+
+- Ground it in a specific signal from the artifacts (e.g., "eval_loss plateaued at step 2800 → suggest cosine annealing with restarts")
+- Estimate **expected impact** (`high` / `medium` / `low`) based on the gap between current performance and where this idea could take it
+- Estimate **effort** (`high` / `medium` / `low`) based on implementation complexity and compute cost
+- Provide a concrete `next_command` when possible (e.g., a CLI flag change, a one-liner code edit, or a training command)
+
+Sort all recommendations by `expected_impact` descending, breaking ties by `effort` ascending (high impact + low effort first).
+
+### 4. Optionally run autoresearch
+
+If `--autoresearch` is set, read the [autoresearch](https://github.com/karpathy/autoresearch) repo and attempt to use it to run some of the recommendations you generated if they fit the autoresearch use case (iterations that take less than 5 mins but can run many of them)
+
+```bash
+uv run autoresearch "<task description derived from artifacts>" --max-papers 10 --output <out-dir>/autoresearch-results.json
+```
+
+Parse the results and merge any literature-grounded suggestions into the recommendation list, tagging them with `"source": "autoresearch"`. If `autoresearch` is unavailable or fails, log a warning and continue with artifact-only recommendations.
+
+Even without `--autoresearch`, you may draw on your knowledge of relevant ML literature to support recommendations — cite paper names or techniques by name where helpful.
+
+### 5. Output a prioritized report
+
+After generating recommendations, produce a readable summary:
+
+```text
+Recommended Next Approaches
+===========================
+Model: <checkpoint or model ID>
+Task: <task_type> — <primary_metric>=<score> (baseline delta: <delta>)
+Diagnostic: <2-3 sentence summary of key weaknesses>
+
+Top Recommendations (sorted by expected impact):
+
+#1 [HIGH impact / LOW effort] — <category>: <idea title>
+   Rationale: <why this matters given the artifacts>
+   Next step: <concrete command or code change>
+
+#2 [HIGH impact / MEDIUM effort] — <category>: <idea title>
+   ...
+
+Decision: CONDITIONAL
+Confidence: medium
+```
+
+Use `CONDITIONAL` as the decision (these are forward-looking suggestions, not a hard gate). Use `GO` if the model already looks strong and only minor improvements remain.
+
+### JSON artifact
+
+Write `recommend-new-approaches.json` to `--out-dir` (or `./` if invoked standalone) following the schema in [../../references/schemas.md](../../references/schemas.md). Use vocabulary from [../../references/vocabulary.md](../../references/vocabulary.md).
+
+Key fields to populate:
+
+- `decision`: `CONDITIONAL` in most cases (recommendations exist); `GO` if model is already near-optimal
+- `model`, `task_type`, `primary_metric`, `current_score`, `baseline_score`, `performance_gap`
+- `diagnostic_summary`: 2–3 sentence summary of key weaknesses
+- `recommendations`: array sorted by `expected_impact` descending — see schema for full shape
+- `autoresearch_used`: `true` / `false`
+- `autoresearch_path`: path to autoresearch output file, or `null`
+- `artifacts_used`: list of artifact paths that were loaded
+
+## Example session
+
+```
+/ml-skills:recommend-new-approaches --out-dir ./reports/run-001
+
+Loading artifacts from ./reports/run-001:
+  ✓ train-model.json — eval_loss=0.312, eval_f1=0.891 (early stopped at step 3200, patience=3)
+  ✓ check-eval.json  — f1=0.891 vs. baseline 0.712 (+0.179); no regressions
+  ✓ explain-model.json — top feature: transaction_amount_zscore; bias: disparate_impact=0.72 (failed)
+  ✗ plan-experiment.json — not found, skipping
+
+Diagnostic:
+  Model trained well (F1 +0.179 over baseline) but stopped early at 32% of planned steps,
+  suggesting the LR schedule may be too aggressive. Bias audit failed on disparate_impact (0.72 < 0.80),
+  and the top feature shows heavy reliance on a single zscore — possible brittleness to distribution shift.
+
+Recommended Next Approaches
+===========================
+Model: ./checkpoints/checkpoint-2800
+Task: classification — eval_f1=0.891 (baseline delta: +0.179)
+
+#1 [HIGH impact / LOW effort] — training: Cosine annealing with warm restarts
+   Rationale: Early stopping triggered at step 3200 (patience=3) — LR plateau likely cause.
+              Cosine restarts let training escape local minima without manual tuning.
+   Next step: uv run train.py --lr_scheduler cosine_with_restarts --warmup_steps 200
+
+#2 [HIGH impact / MEDIUM effort] — loss: Add fairness regularization term
+   Rationale: disparate_impact=0.72 failed the 0.80 threshold. Adversarial debiasing or
+              a fairness penalty on the loss can close the gap without major accuracy loss.
+   Next step: Add FairLearn or AIF360 constraint wrapper around the training objective.
+
+#3 [MEDIUM impact / LOW effort] — regularization: Increase early stopping patience to 7
+   Rationale: patience=3 may be too tight — model stopped before plateau confirmed.
+              A patience of 5–10 is common for tasks with noisy eval metrics.
+   Next step: --early-stop-patience 7
+
+...
+
+Decision: CONDITIONAL
+Confidence: medium
+
+Artifact: ./reports/run-001/recommend-new-approaches.json
+```
+
+## Additional resources
+
+- [autoresearch](https://github.com/karpathy/autoresearch) — automated literature-grounded research ideation
+- [check-eval](../check-eval/SKILL.md) — evaluation results (primary input)
+- [explain-model](../explain-model/SKILL.md) — feature importance and bias (supporting input)
+- [train-model](../train-model/SKILL.md) — training artifacts (supporting input)
+- [../../references/schemas.md](../../references/schemas.md) — JSON artifact schema
+- [../../references/vocabulary.md](../../references/vocabulary.md) — canonical enum values


### PR DESCRIPTION
## Summary

- Add `recommend-new-approaches` skill (stage 10) — synthesizes training artifacts into a prioritized list of research directions, modeling ideas, and loss function modifications; optionally leverages [autoresearch](https://github.com/karpathy/autoresearch)
- Wire it as step 5d in `orchestrate-e2e` (always runs after eval/interpretability gates, informational only)
- Add stage-order column to README skills table; clarify `babysit-training` (6b) and `check-failed-run` (6c) can be invoked standalone
- Add `CHANGELOG.md` with release.yml-matching category conventions; document update process in `AGENTS.md`
- Bump plugin version `0.2.0` → `0.3.0`
- Closes #7, #8
 
## Test plan

- [ ] Invoke `/recommend-new-approaches --out-dir <dir>` after a training run and verify it reads available JSON artifacts and outputs a sorted recommendations list
- [ ] Invoke via `orchestrate-e2e` end-to-end and confirm step 5d runs after `explain-model` without blocking the promotion decision
- [ ] Invoke standalone with no artifacts present and confirm it asks for at least one input before proceeding
- [ ] Verify `recommend-new-approaches.json` is written with correct schema fields (`recommendations[]` sorted by `expected_impact`)
- [ ] Check `--autoresearch` flag path logs a warning gracefully when `autoresearch` is not installed